### PR TITLE
add more fraction math functions

### DIFF
--- a/src/entities/fractions/fraction.test.ts
+++ b/src/entities/fractions/fraction.test.ts
@@ -140,7 +140,6 @@ describe('Fraction', () => {
       ).toBe(true)
     })
   })
-
   describe('#multiplty', () => {
     it('correct', () => {
       expect(

--- a/src/entities/fractions/fraction.test.ts
+++ b/src/entities/fractions/fraction.test.ts
@@ -28,6 +28,24 @@ describe('Fraction', () => {
       expect(new Fraction(JSBI.BigInt(5), JSBI.BigInt(10)).invert().denominator).toEqual(JSBI.BigInt(5))
     })
   })
+  describe('#absoluteValue', () => {
+    it('returns the absolute value of fraction with negative denominator', () => {
+      expect(new Fraction(JSBI.BigInt(5), JSBI.BigInt(-10)).absoluteValue().denominator).toEqual(JSBI.BigInt(10))
+    })
+    it('returns the absolute value of fraction with negative numerator', () => {
+      expect(new Fraction(JSBI.BigInt(-5), JSBI.BigInt(10)).absoluteValue().numerator).toEqual(JSBI.BigInt(5))
+    })
+    it('returns the absolute value of fraction with negative numerator and denominator', () => {
+      const absFraction = new Fraction(JSBI.BigInt(-5), JSBI.BigInt(-10)).absoluteValue()
+      expect(absFraction.numerator).toEqual(JSBI.BigInt(5))
+      expect(absFraction.denominator).toEqual(JSBI.BigInt(10))
+    })
+    it('returns the absolute value of a positive fraction', () => {
+      const absFraction = new Fraction(JSBI.BigInt(5), JSBI.BigInt(10)).absoluteValue()
+      expect(absFraction.numerator).toEqual(JSBI.BigInt(5))
+      expect(absFraction.denominator).toEqual(JSBI.BigInt(10))
+    })
+  })
   describe('#add', () => {
     it('multiples denoms and adds nums', () => {
       expect(new Fraction(JSBI.BigInt(1), JSBI.BigInt(10)).add(new Fraction(JSBI.BigInt(4), JSBI.BigInt(12)))).toEqual(
@@ -92,6 +110,37 @@ describe('Fraction', () => {
       ).toBe(true)
     })
   })
+  describe('#lessThanOrEqualTo', () => {
+    it('correct', () => {
+      expect(
+        new Fraction(JSBI.BigInt(1), JSBI.BigInt(10)).lessThanOrEqualTo(new Fraction(JSBI.BigInt(4), JSBI.BigInt(12)))
+      ).toBe(true)
+      expect(
+        new Fraction(JSBI.BigInt(1), JSBI.BigInt(3)).lessThanOrEqualTo(new Fraction(JSBI.BigInt(4), JSBI.BigInt(12)))
+      ).toBe(true)
+      expect(
+        new Fraction(JSBI.BigInt(5), JSBI.BigInt(12)).lessThanOrEqualTo(new Fraction(JSBI.BigInt(4), JSBI.BigInt(12)))
+      ).toBe(false)
+    })
+  })
+  describe('#greaterThanOrEqualTo', () => {
+    it('correct', () => {
+      expect(
+        new Fraction(JSBI.BigInt(1), JSBI.BigInt(10)).greaterThanOrEqualTo(
+          new Fraction(JSBI.BigInt(4), JSBI.BigInt(12))
+        )
+      ).toBe(false)
+      expect(
+        new Fraction(JSBI.BigInt(1), JSBI.BigInt(3)).greaterThanOrEqualTo(new Fraction(JSBI.BigInt(4), JSBI.BigInt(12)))
+      ).toBe(true)
+      expect(
+        new Fraction(JSBI.BigInt(5), JSBI.BigInt(12)).greaterThanOrEqualTo(
+          new Fraction(JSBI.BigInt(4), JSBI.BigInt(12))
+        )
+      ).toBe(true)
+    })
+  })
+
   describe('#multiplty', () => {
     it('correct', () => {
       expect(

--- a/src/entities/fractions/fraction.ts
+++ b/src/entities/fractions/fraction.ts
@@ -52,6 +52,16 @@ export class Fraction {
     return new Fraction(this.denominator, this.numerator)
   }
 
+  public absoluteValue(): Fraction {
+    const numeratorAbs = JSBI.lessThan(this.numerator, JSBI.BigInt(0))
+      ? JSBI.unaryMinus(this.numerator)
+      : this.numerator
+    const denominatorAbs = JSBI.lessThan(this.denominator, JSBI.BigInt(0))
+      ? JSBI.unaryMinus(this.denominator)
+      : this.denominator
+    return new Fraction(numeratorAbs, denominatorAbs)
+  }
+
   public add(other: Fraction | BigintIsh): Fraction {
     const otherParsed = Fraction.tryParseFraction(other)
     if (JSBI.equal(this.denominator, otherParsed.denominator)) {
@@ -102,6 +112,14 @@ export class Fraction {
       JSBI.multiply(this.numerator, otherParsed.denominator),
       JSBI.multiply(otherParsed.numerator, this.denominator)
     )
+  }
+
+  public lessThanOrEqualTo(other: Fraction | BigintIsh): boolean {
+    return this.lessThan(other) || this.equalTo(other)
+  }
+
+  public greaterThanOrEqualTo(other: Fraction | BigintIsh): boolean {
+    return this.greaterThan(other) || this.equalTo(other)
   }
 
   public multiply(other: Fraction | BigintIsh): Fraction {


### PR DESCRIPTION
These functions would've made my routing-api code cleaner. Plus I discovered a bug with how I was doing absolute value in there. `Fraction.lessThan()` is broken when comparing negative fraction to 0, as multiplying by 0 will cancel out the negative number.

reference: https://github.com/Uniswap/smart-order-router/blob/main/src/routers/alpha-router/alpha-router.ts#L214

Also JSBI has no absolute value function. whyyy do we like JSBI. 