### PR TITLE
Add Boba WETH

### DIFF
--- a/src/entities/weth9.ts
+++ b/src/entities/weth9.ts
@@ -12,6 +12,9 @@ export const WETH9: { [chainId: number]: Token } = {
 
   [10]: new Token(10, '0x4200000000000000000000000000000000000006', 18, 'WETH', 'Wrapped Ether'),
   [69]: new Token(69, '0x4200000000000000000000000000000000000006', 18, 'WETH', 'Wrapped Ether'),
+  
+  [28]: new Token(28, '0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000', 18, 'WETH', 'Wrapped Ether'),
+  [288]: new Token(288, '0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000', 18, 'WETH', 'Wrapped Ether'),
 
   [42161]: new Token(42161, '0x82aF49447D8a07e3bd95BD0d56f35241523fBab1', 18, 'WETH', 'Wrapped Ether'),
   [421611]: new Token(421611, '0xB47e6A5f8b33b3F17603C83a0535A9dcD7E32681', 18, 'WETH', 'Wrapped Ether')


### PR DESCRIPTION
I'm using the UniV2 SDK on [Boba](https://boba.network/). Understand if you won't accept since Uniswap doesn't officially support Boba.

address source: [omgnetwork/optimism-v2/.../packages/contracts/src/predeploys.ts](https://github.com/omgnetwork/optimism-v2/blob/05af83878331fff61ee41d0eac94af8648df83be/packages/contracts/src/predeploys.ts#L25)