### PR TITLE
feat: remove ropsten, rinkeby, kovan, arbitrum_rinkeby support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@uniswap/sdk-core",
   "license": "MIT",
-  "version": "3.1.2",
+  "version": "4.0.0",
   "description": "⚒️ An SDK for building applications on top of Uniswap V3",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,13 +2,9 @@ import JSBI from 'jsbi'
 
 export enum SupportedChainId {
   MAINNET = 1,
-  ROPSTEN = 3,
-  RINKEBY = 4,
   GOERLI = 5,
-  KOVAN = 42,
 
   ARBITRUM_ONE = 42161,
-  ARBITRUM_RINKEBY = 421611,
   ARBITRUM_GOERLI = 421613,
 
   OPTIMISM = 10,


### PR DESCRIPTION
None of these chains have support for Universal Router, and they are also deprecated. This will require a major version as it's not backwards compatible.