### PR TITLE
feat: lowercase address checking when doing token comparisons

### DIFF
--- a/src/entities/token.test.ts
+++ b/src/entities/token.test.ts
@@ -3,6 +3,7 @@ import { Token } from './token'
 describe('Token', () => {
   const ADDRESS_ONE = '0x0000000000000000000000000000000000000001'
   const ADDRESS_TWO = '0x0000000000000000000000000000000000000002'
+  const DAI_MAINNET = '0x6B175474E89094C44Da98b954EedeAC495271d0F'
 
   describe('#constructor', () => {
     it('fails with invalid address', () => {
@@ -69,6 +70,12 @@ describe('Token', () => {
     it('true even if name/symbol/decimals differ', () => {
       const tokenA = new Token(1, ADDRESS_ONE, 9, 'abc', 'def')
       const tokenB = new Token(1, ADDRESS_ONE, 18, 'ghi', 'jkl')
+      expect(tokenA.equals(tokenB)).toBe(true)
+    })
+
+    it('true even if one token is checksummed and the other is not', () => {
+      const tokenA = new Token(1, DAI_MAINNET, 18, 'DAI', undefined, false)
+      const tokenB  = new Token(1, DAI_MAINNET.toLowerCase(), 18, 'DAI', undefined, true)
       expect(tokenA.equals(tokenB)).toBe(true)
     })
   })

--- a/src/entities/token.test.ts
+++ b/src/entities/token.test.ts
@@ -75,7 +75,7 @@ describe('Token', () => {
 
     it('true even if one token is checksummed and the other is not', () => {
       const tokenA = new Token(1, DAI_MAINNET, 18, 'DAI', undefined, false)
-      const tokenB  = new Token(1, DAI_MAINNET.toLowerCase(), 18, 'DAI', undefined, true)
+      const tokenB = new Token(1, DAI_MAINNET.toLowerCase(), 18, 'DAI', undefined, true)
       expect(tokenA.equals(tokenB)).toBe(true)
     })
   })

--- a/src/entities/token.ts
+++ b/src/entities/token.ts
@@ -45,7 +45,7 @@ export class Token extends BaseCurrency {
    * @param other other token to compare
    */
   public equals(other: Currency): boolean {
-    return other.isToken && this.chainId === other.chainId && this.address === other.address
+    return other.isToken && this.chainId === other.chainId && this.address.toLowerCase() === other.address.toLowerCase()
   }
 
   /**
@@ -56,7 +56,7 @@ export class Token extends BaseCurrency {
    */
   public sortsBefore(other: Token): boolean {
     invariant(this.chainId === other.chainId, 'CHAIN_IDS')
-    invariant(this.address !== other.address, 'ADDRESSES')
+    invariant(this.address.toLowerCase() !== other.address.toLowerCase(), 'ADDRESSES')
     return this.address.toLowerCase() < other.address.toLowerCase()
   }
 


### PR DESCRIPTION
Because Tokens can now have non-checksummed addresses, we need to lowercase addresses before doing comparison checking because we could be comparing one with checksummed addresses to one without. Theoretically they're the same token, so its OK to not do case-sensitive comparisons here