### PR TITLE
fix: the object reduce return a string

### DIFF
--- a/src/addresses.ts
+++ b/src/addresses.ts
@@ -143,7 +143,10 @@ export const CHAIN_TO_ADDRESSES_MAP: Record<SupportedChainsType, ChainAddresses>
 /* V3 Contract Addresses */
 export const V3_CORE_FACTORY_ADDRESSES: AddressMap = {
   ...SUPPORTED_CHAINS.reduce<AddressMap>(
-    (memo, chainId) => (memo[chainId] = CHAIN_TO_ADDRESSES_MAP[chainId].v3CoreFactoryAddress),
+    (memo, chainId) => {
+      memo[chainId] = CHAIN_TO_ADDRESSES_MAP[chainId].v3CoreFactoryAddress
+      return memo
+    },
     {}
   )
 }
@@ -160,7 +163,10 @@ export const V3_MIGRATOR_ADDRESSES: AddressMap = {
 
 export const MULTICALL_ADDRESSES: AddressMap = {
   ...SUPPORTED_CHAINS.reduce<AddressMap>(
-    (memo, chainId) => (memo[chainId] = CHAIN_TO_ADDRESSES_MAP[chainId].multicallAddress),
+    (memo, chainId) => {
+      memo[chainId] = CHAIN_TO_ADDRESSES_MAP[chainId].multicallAddress
+      return memo
+    },
     {}
   )
 }
@@ -196,7 +202,10 @@ export const ARGENT_WALLET_DETECTOR_ADDRESS: AddressMap = {
 
 export const QUOTER_ADDRESSES: AddressMap = {
   ...SUPPORTED_CHAINS.reduce<AddressMap>(
-    (memo, chainId) => (memo[chainId] = CHAIN_TO_ADDRESSES_MAP[chainId].quoterAddress),
+    (memo, chainId) => {
+      memo[chainId] = CHAIN_TO_ADDRESSES_MAP[chainId].quoterAddress
+      return memo
+    },
     {}
   )
 }


### PR DESCRIPTION
I'm getting an error using version 3.2.4, details are as follows.

``` 
return memo[chainId] = CHAIN_TO_ADDRESSES_MAP[chainId].v3CoreFactoryAddress;
                       ^

TypeError: Cannot assign to read only property '10' of string '0x1F98431c8aD98523631AE4a59f267346ea31F984'
    at D:\workspace\sdk-core\dist\sdk-core.cjs.development.js:190:24
```