### PR TITLE
chore: publish 3.2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@uniswap/sdk-core",
   "license": "MIT",
-  "version": "3.2.5",
+  "version": "3.2.6",
   "description": "⚒️ An SDK for building applications on top of Uniswap V3",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
The was an error between the keyboard and the chair when publishing 3.2.5 where the project was not built before publishing. This is resolved in 3.2.6.