### PR TITLE
circular dependency between Currency, BaseCurrency and NativeCurrency…

### DIFF
--- a/src/entities/baseCurrency.ts
+++ b/src/entities/baseCurrency.ts
@@ -1,5 +1,4 @@
 import invariant from 'tiny-invariant'
-import { Currency } from './currency'
 import { Token } from './token'
 
 /**
@@ -53,7 +52,7 @@ export abstract class BaseCurrency {
    * Returns whether this currency is functionally equivalent to the other currency
    * @param other the other currency
    */
-  public abstract equals(other: Currency): boolean
+  public abstract equals(other: BaseCurrency): boolean
 
   /**
    * Return the wrapped version of this currency that can be used with the Uniswap contracts. Currencies must


### PR DESCRIPTION
… #12

- Removed a cicular dependency by changing `equals(other: Currency)` to `equals(other: BaseCurrency)` per comment at https://github.com/Uniswap/sdk-core/issues/12#issuecomment-1176801759