### PR TITLE
fix: temporarily remove base from supported_chains

### DIFF
--- a/src/chains.ts
+++ b/src/chains.ts
@@ -31,7 +31,7 @@ export const SUPPORTED_CHAINS = [
   ChainId.CELO_ALFAJORES,
   ChainId.CELO,
   ChainId.BNB,
-  ChainId.AVALANCHE,
+  ChainId.AVALANCHE
 ] as const
 export type SupportedChainsType = typeof SUPPORTED_CHAINS[number]
 

--- a/src/chains.ts
+++ b/src/chains.ts
@@ -32,8 +32,6 @@ export const SUPPORTED_CHAINS = [
   ChainId.CELO,
   ChainId.BNB,
   ChainId.AVALANCHE,
-  ChainId.BASE,
-  ChainId.BASE_GOERLI
 ] as const
 export type SupportedChainsType = typeof SUPPORTED_CHAINS[number]
 


### PR DESCRIPTION
remove these so that the interface can upgrade to the latest major version without adding BASE support