### PR TITLE
Add Rootstock `chainId`

### DIFF
--- a/src/chains.ts
+++ b/src/chains.ts
@@ -15,7 +15,8 @@ export enum ChainId {
   BNB = 56,
   AVALANCHE = 43114,
   BASE_GOERLI = 84531,
-  BASE = 8453
+  BASE = 8453,
+  ROOTSTOCK = 30
 }
 
 export const SUPPORTED_CHAINS = [


### PR DESCRIPTION
### Description
This PR adds [Rootstock](rootstock.io) chain id to this core sdk as integration proposal for Rootstock with Uniswap is under review. 

### Reason
To continue with rootstock integration in other Uniswap repos the chainId needs to be supported by sdk-core.

### Any Questions
Feel free to ask any questions regarding the consideration of this pull request. 