### PR TITLE
Add new WETH9 token address for chain ID 8453 (BASE)

### DIFF
--- a/src/entities/weth9.ts
+++ b/src/entities/weth9.ts
@@ -15,4 +15,5 @@ export const WETH9: { [chainId: number]: Token } = {
 
   [42161]: new Token(42161, '0x82aF49447D8a07e3bd95BD0d56f35241523fBab1', 18, 'WETH', 'Wrapped Ether'),
   [421611]: new Token(421611, '0xB47e6A5f8b33b3F17603C83a0535A9dcD7E32681', 18, 'WETH', 'Wrapped Ether')
+  [8453]: new Token(8453, '0x4200000000000000000000000000000000000006', 18, 'WETH', 'Wrapped Ether')
 }


### PR DESCRIPTION
# Summary:
This PR adds support for the WETH9 token address associated with chain ID 8453.

## Changes:

Added a new key-value pair to the WETH9 mapping for chain ID 8453.