### PR TITLE
feat: add v2 factory chains

### DIFF
--- a/src/addresses.ts
+++ b/src/addresses.ts
@@ -13,7 +13,7 @@ type ChainAddresses = {
   v1MixedRouteQuoterAddress?: string
 }
 
-const DEFAULT_NETWORKS = [ChainId.MAINNET, ChainId.GOERLI]
+const DEFAULT_NETWORKS = [ChainId.MAINNET, ChainId.GOERLI, ChainId.SEPOLIA]
 
 function constructSameAddressMap(address: string, additionalNetworks: ChainId[] = []): AddressMap {
   return DEFAULT_NETWORKS.concat(additionalNetworks).reduce<AddressMap>((memo, chainId) => {
@@ -33,7 +33,10 @@ export const UNI_ADDRESSES: AddressMap = constructSameAddressMap('0x1f9840a85d5a
 export const UNISWAP_NFT_AIRDROP_CLAIM_ADDRESS = '0x8B799381ac40b838BBA4131ffB26197C432AFe78'
 
 export const V2_FACTORY_ADDRESS = '0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f'
-export const V2_FACTORY_ADDRESSES: AddressMap = constructSameAddressMap(V2_FACTORY_ADDRESS)
+export const V2_FACTORY_ADDRESSES: AddressMap = constructSameAddressMap(
+  V2_FACTORY_ADDRESS, 
+  [ChainId.POLYGON, ChainId.OPTIMISM, ChainId.CELO, ChainId.ARBITRUM_ONE, ChainId.BNB, ChainId.AVALANCHE, ChainId.BASE]
+)
 export const V2_ROUTER_ADDRESS = '0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D'
 export const V2_ROUTER_ADDRESSES: AddressMap = constructSameAddressMap(V2_ROUTER_ADDRESS)
 

--- a/src/addresses.ts
+++ b/src/addresses.ts
@@ -33,10 +33,15 @@ export const UNI_ADDRESSES: AddressMap = constructSameAddressMap('0x1f9840a85d5a
 export const UNISWAP_NFT_AIRDROP_CLAIM_ADDRESS = '0x8B799381ac40b838BBA4131ffB26197C432AFe78'
 
 export const V2_FACTORY_ADDRESS = '0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f'
-export const V2_FACTORY_ADDRESSES: AddressMap = constructSameAddressMap(
-  V2_FACTORY_ADDRESS, 
-  [ChainId.POLYGON, ChainId.OPTIMISM, ChainId.CELO, ChainId.ARBITRUM_ONE, ChainId.BNB, ChainId.AVALANCHE, ChainId.BASE]
-)
+export const V2_FACTORY_ADDRESSES: AddressMap = constructSameAddressMap(V2_FACTORY_ADDRESS, [
+  ChainId.POLYGON,
+  ChainId.OPTIMISM,
+  ChainId.CELO,
+  ChainId.ARBITRUM_ONE,
+  ChainId.BNB,
+  ChainId.AVALANCHE,
+  ChainId.BASE
+])
 export const V2_ROUTER_ADDRESS = '0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D'
 export const V2_ROUTER_ADDRESSES: AddressMap = constructSameAddressMap(V2_ROUTER_ADDRESS)
 


### PR DESCRIPTION
the v2 factory was deployed to these chains at the same address as mainnet.

also, we already support v2 on sepolia.

- [linear ticket](https://linear.app/uniswap/issue/WEB-2834/compile-list-of-deployed-v2-contracts-for-new-chains)
- [slack thread](https://uniswapteam.slack.com/archives/C05MF1J6GR5/p1694466968450459)