### PR TITLE
Add quoter V2 contract addresses

### DIFF
--- a/src/addresses.ts
+++ b/src/addresses.ts
@@ -6,6 +6,7 @@ type ChainAddresses = {
   v3CoreFactoryAddress: string
   multicallAddress: string
   quoterAddress: string
+  quoterV2Address: string
   v3MigratorAddress?: string
   nonfungiblePositionManagerAddress?: string
   tickLensAddress?: string
@@ -50,6 +51,7 @@ const DEFAULT_ADDRESSES: ChainAddresses = {
   v3CoreFactoryAddress: '0x1F98431c8aD98523631AE4a59f267346ea31F984',
   multicallAddress: '0x1F98415757620B543A52E61c46B32eB19261F984',
   quoterAddress: '0xb27308f9F90D607463bb33eA1BeBb41C27CE5AB6',
+  quoterV2Address: '0x61fFE014bA17989E743c5F6cB21bF9697530B21e',
   v3MigratorAddress: '0xA5644E29708357803b5A882D272c41cC0dF92B34',
   nonfungiblePositionManagerAddress: '0xC36442b4a4522E871399CD717aBDD847Ab11FE88'
 }
@@ -75,6 +77,7 @@ const CELO_ADDRESSES: ChainAddresses = {
   v3CoreFactoryAddress: '0xAfE208a311B21f13EF87E33A90049fC17A7acDEc',
   multicallAddress: '0x633987602DE5C4F337e3DbF265303A1080324204',
   quoterAddress: '0x82825d0554fA07f7FC52Ab63c961F330fdEFa8E8',
+  quoterV2Address: '0x82825d0554fA07f7FC52Ab63c961F330fdEFa8E8',
   v3MigratorAddress: '0x3cFd4d48EDfDCC53D3f173F596f621064614C582',
   nonfungiblePositionManagerAddress: '0x3d79EdAaBC0EaB6F08ED885C05Fc0B014290D95A',
   tickLensAddress: '0x5f115D9113F88e0a0Db1b5033D90D4a9690AcD3D'
@@ -85,6 +88,7 @@ const BNB_ADDRESSES: ChainAddresses = {
   v3CoreFactoryAddress: '0xdB1d10011AD0Ff90774D0C6Bb92e5C5c8b4461F7',
   multicallAddress: '0x963Df249eD09c358A4819E39d9Cd5736c3087184',
   quoterAddress: '0x78D78E420Da98ad378D7799bE8f4AF69033EB077',
+  quoterV2Address: '0x78D78E420Da98ad378D7799bE8f4AF69033EB077',
   v3MigratorAddress: '0x32681814957e0C13117ddc0c2aba232b5c9e760f',
   nonfungiblePositionManagerAddress: '0x7b8A01B39D58278b5DE7e48c8449c9f4F5170613',
   tickLensAddress: '0xD9270014D396281579760619CCf4c3af0501A47C',
@@ -96,6 +100,7 @@ const OPTIMISM_GOERLI_ADDRESSES: ChainAddresses = {
   v3CoreFactoryAddress: '0xB656dA17129e7EB733A557f4EBc57B76CFbB5d10',
   multicallAddress: '0x07F2D8a2a02251B62af965f22fC4744A5f96BCCd',
   quoterAddress: '0x9569CbA925c8ca2248772A9A4976A516743A246F',
+  quoterV2Address: '0x9569CbA925c8ca2248772A9A4976A516743A246F',
   v3MigratorAddress: '0xf6c55fBe84B1C8c3283533c53F51bC32F5C7Aba8',
   nonfungiblePositionManagerAddress: '0x39Ca85Af2F383190cBf7d7c41ED9202D27426EF6',
   tickLensAddress: '0xe6140Bd164b63E8BfCfc40D5dF952f83e171758e'
@@ -106,6 +111,7 @@ const ARBITRUM_GOERLI_ADDRESSES: ChainAddresses = {
   v3CoreFactoryAddress: '0x4893376342d5D7b3e31d4184c08b265e5aB2A3f6',
   multicallAddress: '0x8260CB40247290317a4c062F3542622367F206Ee',
   quoterAddress: '0x1dd92b83591781D0C6d98d07391eea4b9a6008FA',
+  quoterV2Address: '0x1dd92b83591781D0C6d98d07391eea4b9a6008FA',
   v3MigratorAddress: '0xA815919D2584Ac3F76ea9CB62E6Fd40a43BCe0C3',
   nonfungiblePositionManagerAddress: '0x622e4726a167799826d1E1D150b076A7725f5D81',
   tickLensAddress: '0xb52429333da969a0C79a60930a4Bf0020E5D1DE8'
@@ -116,6 +122,7 @@ const SEPOLIA_ADDRESSES: ChainAddresses = {
   v3CoreFactoryAddress: '0x0227628f3F023bb0B980b67D528571c95c6DaC1c',
   multicallAddress: '0xD7F33bCdb21b359c8ee6F0251d30E94832baAd07',
   quoterAddress: '0xEd1f6473345F45b75F8179591dd5bA1888cf2FB3',
+  quoterV2Address: '0xEd1f6473345F45b75F8179591dd5bA1888cf2FB3',
   v3MigratorAddress: '0x729004182cF005CEC8Bd85df140094b6aCbe8b15',
   nonfungiblePositionManagerAddress: '0x1238536071E1c677A632429e3655c799b22cDA52',
   tickLensAddress: '0xd7f33bcdb21b359c8ee6f0251d30e94832baad07'
@@ -126,6 +133,7 @@ const AVALANCHE_ADDRESSES: ChainAddresses = {
   v3CoreFactoryAddress: '0x740b1c1de25031C31FF4fC9A62f554A55cdC1baD',
   multicallAddress: '0x0139141Cd4Ee88dF3Cdb65881D411bAE271Ef0C2',
   quoterAddress: '0xbe0F5544EC67e9B3b2D979aaA43f18Fd87E6257F',
+  quoterV2Address: '0xbe0F5544EC67e9B3b2D979aaA43f18Fd87E6257F',
   v3MigratorAddress: '0x44f5f1f5E452ea8d29C890E8F6e893fC0f1f0f97',
   nonfungiblePositionManagerAddress: '0x655C406EBFa14EE2006250925e54ec43AD184f8B',
   tickLensAddress: '0xEB9fFC8bf81b4fFd11fb6A63a6B0f098c6e21950',
@@ -136,6 +144,7 @@ const BASE_ADDRESSES: ChainAddresses = {
   v3CoreFactoryAddress: '0x33128a8fC17869897dcE68Ed026d694621f6FDfD',
   multicallAddress: '0x091e99cb1C49331a94dD62755D168E941AbD0693',
   quoterAddress: '0x3d4e44Eb1374240CE5F1B871ab261CD16335B76a',
+  quoterV2Address: '0x3d4e44Eb1374240CE5F1B871ab261CD16335B76a',
   v3MigratorAddress: '0x23cF10b1ee3AdfCA73B0eF17C07F7577e7ACd2d7',
   nonfungiblePositionManagerAddress: '0x03a520b32C04BF3bEEf7BEb72E919cf822Ed34f1',
   tickLensAddress: '0x0CdeE061c75D43c82520eD998C23ac2991c9ac6d',
@@ -147,6 +156,7 @@ const BASE_GOERLI_ADDRESSES: ChainAddresses = {
   v3CoreFactoryAddress: '0x9323c1d6D800ed51Bd7C6B216cfBec678B7d0BC2',
   multicallAddress: '0xB206027a9E0E13F05eBEFa5D2402Bab3eA716439',
   quoterAddress: '0xedf539058e28E5937dAef3f69cEd0b25fbE66Ae9',
+  quoterV2Address: '0xedf539058e28E5937dAef3f69cEd0b25fbE66Ae9',
   v3MigratorAddress: '0x3efe5d02a04b7351D671Db7008ec6eBA9AD9e3aE',
   nonfungiblePositionManagerAddress: '0x3c61369ef0D1D2AFa70d8feC2F31C5D6Ce134F30',
   tickLensAddress: '0x1acB873Ee909D0c98adB18e4474943249F931b92',


### PR DESCRIPTION
### Description
The [Quoter](https://github.com/Uniswap/v3-periphery/blob/697c2474757ea89fec12a4e6db16a574fe259610/contracts/interfaces/IQuoter.sol#L4) and [QuoterV2](https://github.com/Uniswap/v3-periphery/blob/697c2474757ea89fec12a4e6db16a574fe259610/contracts/interfaces/IQuoter.sol#L4) contracts have different interfaces.

On chains where both are deployed (e.g. Mainnet/Optimism/Polygon) it's useful to be able to get the explicit address of the QuoterV2. 