### PR TITLE
chore(networks): add Base Sepolia

### DIFF
--- a/src/addresses.ts
+++ b/src/addresses.ts
@@ -153,6 +153,17 @@ const BASE_GOERLI_ADDRESSES: ChainAddresses = {
   swapRouter02Address: '0x8357227D4eDc78991Db6FDB9bD6ADE250536dE1d'
 }
 
+// Base Sepolia v3 addresses
+const BASE_SEPOLIA_ADDRESSES: ChainAddresses = {
+  v3CoreFactoryAddress: '',
+  multicallAddress: '',
+  quoterAddress: '',
+  v3MigratorAddress: '',
+  nonfungiblePositionManagerAddress: '',
+  tickLensAddress: '',
+  swapRouter02Address: ''
+}
+
 export const CHAIN_TO_ADDRESSES_MAP: Record<SupportedChainsType, ChainAddresses> = {
   [ChainId.MAINNET]: MAINNET_ADDRESSES,
   [ChainId.OPTIMISM]: OPTIMISM_ADDRESSES,
@@ -168,7 +179,8 @@ export const CHAIN_TO_ADDRESSES_MAP: Record<SupportedChainsType, ChainAddresses>
   [ChainId.SEPOLIA]: SEPOLIA_ADDRESSES,
   [ChainId.AVALANCHE]: AVALANCHE_ADDRESSES,
   [ChainId.BASE]: BASE_ADDRESSES,
-  [ChainId.BASE_GOERLI]: BASE_GOERLI_ADDRESSES
+  [ChainId.BASE_GOERLI]: BASE_GOERLI_ADDRESSES,
+  [ChainId.BASE_SEPOLIA]: BASE_SEPOLIA_ADDRESSES
 }
 
 /* V3 Contract Addresses */

--- a/src/chains.ts
+++ b/src/chains.ts
@@ -15,6 +15,7 @@ export enum ChainId {
   BNB = 56,
   AVALANCHE = 43114,
   BASE_GOERLI = 84531,
+  BASE_SEPOLIA = 84532,
   BASE = 8453
 }
 
@@ -33,7 +34,8 @@ export const SUPPORTED_CHAINS = [
   ChainId.BNB,
   ChainId.AVALANCHE,
   ChainId.BASE,
-  ChainId.BASE_GOERLI
+  ChainId.BASE_GOERLI,
+  ChainId.BASE_SEPOLIA
 ] as const
 export type SupportedChainsType = typeof SUPPORTED_CHAINS[number]
 


### PR DESCRIPTION
### Base Testnet (Sepolia)
| Name | Value |
|---|---|
| Network Name | Base Sepolia | 
| Description | A public testnet for Base. |
| RPC Endpoint | https://sepolia.base.org |
| Chain ID | 84532 |
| Currency Symbol | ETH |
| Block Explorer | https://sepolia-explorer.base.org/ |
