### PR TITLE
Upgrade jsbi to 3.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@ethersproject/address": "^5.0.2",
     "big.js": "^5.2.2",
     "decimal.js-light": "^2.5.0",
-    "jsbi": "^3.1.4",
+    "jsbi": "^3.2.4",
     "tiny-invariant": "^1.1.0",
     "toformat": "^2.0.0"
   },


### PR DESCRIPTION
Resolves https://github.com/Uniswap/v3-sdk/issues/94

[This SO solution](https://stackoverflow.com/questions/73673535/server-error-error-convert-jsbi-instances-to-native-numbers-using-tonumber/73673536#73673536) recommends jsbi@3.2.5, however, in running v3-sdk tests the error `Could not parse fraction` is still occurring from `Fraction.tryParseFunction`, where it doesn't recognize the passed in variable `fractionish` as  `instanceof JSB`. I suspect this is happening because the instance's prototype is lost between the different libraries due to transpilation to CommonJS, hence why `fractionish instanceof JSBI` works in sdk-core but not in v3-sdk.

I did check the transpiled `sdk-core` code and you can see that the passed in var `other` loses its type signatures, so when compared in `tryParseFraction` the check returns false.

```javascript
  _proto.lessThan = function lessThan(other) {
    var otherParsed = Fraction.tryParseFraction(other);
    return JSBI.lessThan(JSBI.multiply(this.numerator, otherParsed.denominator), JSBI.multiply(otherParsed.numerator, this.denominator));
  };

...

  Fraction.tryParseFraction = function tryParseFraction(fractionish) {
    if (fractionish instanceof JSBI || typeof fractionish === 'number' || typeof fractionish === 'string') {
      return new Fraction(fractionish);
    }
    if ('numerator' in fractionish && 'denominator' in fractionish) return fractionish;
    throw new Error('Could not parse fraction');
  }
```

Checking `typeof fractionish === 'object'` is not robust enough since a `Fraction` will also be of type `object`.

[JSBI is a subclass of Array](https://github.com/GoogleChromeLabs/jsbi/issues/15), hence the recommended solution to check for `fractionish instanceof Array`.