### PR TITLE
fractionish instanceof Array instead of JSBI

### DIFF
--- a/src/entities/fractions/fraction.ts
+++ b/src/entities/fractions/fraction.ts
@@ -31,7 +31,7 @@ export class Fraction {
   }
 
   private static tryParseFraction(fractionish: BigintIsh | Fraction): Fraction {
-    if (fractionish instanceof JSBI || typeof fractionish === 'number' || typeof fractionish === 'string')
+    if (fractionish instanceof Array || typeof fractionish === 'number' || typeof fractionish === 'string')
       return new Fraction(fractionish)
 
     if ('numerator' in fractionish && 'denominator' in fractionish) return fractionish


### PR DESCRIPTION
Resolves https://github.com/Uniswap/v3-sdk/issues/94

[This SO solution](https://stackoverflow.com/questions/73673535/server-error-error-convert-jsbi-instances-to-native-numbers-using-tonumber/73673536#73673536) simply recommends using jsbi@3.2.5, however, in running v3-sdk tests I was still getting the error `Could not parse fraction`, occurring from `Fraction.tryParseFunction`. The transpiled sdk-core package doesn't seem to recognize the passed in variable `fractionish` as an instance of JSBI (perhaps due to loss of type signatures from transpilation).

[JSBI is a subclass of Array](https://github.com/GoogleChromeLabs/jsbi/issues/15), hence one workaround is to instead do this check:

```javascript
fractionish instanceof Array
```