### PR TITLE
Fixed bug that returned an empty swap router 02 address for base chain

### DIFF
--- a/src/addresses.test.ts
+++ b/src/addresses.test.ts
@@ -1,0 +1,26 @@
+import {SWAP_ROUTER_02_ADDRESSES} from "./addresses";
+import {ChainId} from "./chains";
+
+describe('addresses', () => {
+    describe('swap router 02 addresses', () => {
+        it('should return the correct address for base', () => {
+            const address = SWAP_ROUTER_02_ADDRESSES(ChainId.BASE)
+            expect(address).toEqual('0x2626664c2603336E57B271c5C0b26F421741e481')
+        });
+
+        it('should return the correct address for base goerli', () => {
+            const address = SWAP_ROUTER_02_ADDRESSES(ChainId.BASE_GOERLI)
+            expect(address).toEqual('0x8357227D4eDc78991Db6FDB9bD6ADE250536dE1d')
+        });
+
+        it('should return the correct address for avalanche', () => {
+            const address = SWAP_ROUTER_02_ADDRESSES(ChainId.AVALANCHE)
+            expect(address).toEqual('0xbb00FF08d01D300023C629E8fFfFcb65A5a578cE')
+        });
+
+        it('should return the correct address for BNB', () => {
+            const address = SWAP_ROUTER_02_ADDRESSES(ChainId.BNB)
+            expect(address).toEqual('0xB971eF87ede563556b2ED4b1C0b0019111Dd85d2')
+        });
+    });
+});

--- a/src/addresses.ts
+++ b/src/addresses.ts
@@ -310,7 +310,7 @@ export const MIXED_ROUTE_QUOTER_V1_ADDRESSES: AddressMap = SUPPORTED_CHAINS.redu
 }, {})
 
 export const SWAP_ROUTER_02_ADDRESSES = (chainId: number) => {
-  if (chainId in SUPPORTED_CHAINS) {
+  if (SUPPORTED_CHAINS.includes(chainId)) {
     const id = chainId as SupportedChainsType
     return CHAIN_TO_ADDRESSES_MAP[id].swapRouter02Address ?? '0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45'
   }


### PR DESCRIPTION
I was recieiving an error:
`Error: resolver or addr is not configured for ENS name (argument="name", value="", code=INVALID_ARGUMENT, version=contracts/5.7.0)` 
and tracked it down to this bug. It seems that calling `includes()` on the array works but `chainId in SUPPORTED_CHAINS` doesn't. 