### PR TITLE
[wip; dont merge] chore: bump to v4.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@uniswap/sdk-core",
   "license": "MIT",
-  "version": "4.1.3",
+  "version": "4.2.0",
   "description": "⚒️ An SDK for building applications on top of Uniswap V3",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
Release Chain support to RootStock and Zora:
https://github.com/Uniswap/sdk-core/pull/123
https://github.com/Uniswap/sdk-core/pull/121

we might have to change to v4.3.0.